### PR TITLE
fix missing dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ impacket = "^0.10.0"
 dnspython = "^2.2.1"
 pycryptodomex = "^3.15.0"
 ldap3 = "^2.9"
+chardet = "^5.2.0"
 
 [tool.poetry.scripts]
 hekatomb = "src.hekatomb:main"


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/bin/hekatomb", line 5, in <module>
    from src.hekatomb import main
  File "/usr/lib/python3.11/site-packages/src/hekatomb.py", line 34, in <module>
    from impacket.examples.smbclient import MiniImpacketShell
  File "/usr/lib/python3.11/site-packages/impacket/examples/smbclient.py", line 35, in <module>
    import chardet
ModuleNotFoundError: No module named 'chardet'
```